### PR TITLE
add Emacs version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can do it manually from the repl too:
 
 The included slamhound.el allows for convenient access within Slime
 sessions via M-x slamhound as well as running it over an entire
-project with M-x slamhound-project. 
+project with M-x slamhound-project.
 
 Emacs version 24 or greater is required.
 


### PR DESCRIPTION
slamhound.el calls just-one-space w/ a negative argument to also delete newlines around point. This feature of  just-one-space was added in Emacs 24, so slamhound.el cannot be used with older Emacsen.

This is somewhat unfortunate given that Emacs 24 hasn't been released yet.
