### PR TITLE
Exclude temp files from slamhound

### DIFF
--- a/src/slam/hound.clj
+++ b/src/slam/hound.clj
@@ -34,7 +34,7 @@
   [& file-or-dirs]
   (doseq [file-or-dir file-or-dirs
           file (file-seq (io/file file-or-dir))
-          :when (re-find #"/[^\./]+\.clj" (str file))]
+          :when (re-find #"/[^\./]+\.clj$" (str file))]
     (try
       (swap-in-reconstructed-ns-form file)
       (catch Exception e


### PR DESCRIPTION
Don't try to parse emacs tmp files.
