### PR TITLE
Fix var conflicts among different namespaces with improved :require-as matching

### DIFF
--- a/src/slam/hound/regrow.clj
+++ b/src/slam/hound/regrow.clj
@@ -127,6 +127,11 @@
            (some (fn [[ns2 _ [alias2]]]
                    (and (= alias1 alias2) (= ns1 ns2))))))))
 
+(defn- last-segment-matches? [expr]
+  (when (and (coll? expr) (= (second expr) :as))
+    (let [[x _ y] expr]
+      (= (peek (string/split (name x) #"\.")) (name y)))))
+
 (defn- disambiguate [candidates missing ns-map type]
   ;; TODO: prefer things in src/classes to jars
   (debug :disambiguating missing :in candidates)
@@ -136,7 +141,7 @@
          (sort-by (juxt (complement (in-originals-pred orig-clauses))
                         (complement (referred-to-in-originals-pred
                                      type orig-clauses))
-                        ;; TODO: prefer candidates where last segment matches
+                        (complement last-segment-matches?)
                         (comp count str)))
          (remove #(re-find disambiguator-blacklist (str %)))
          first)))

--- a/test/slam/hound/regrow_test.clj
+++ b/test/slam/hound/regrow_test.clj
@@ -87,7 +87,12 @@
                                      java.util.UUID]
                            :refer-clojure '(:exclude [compile test])
                            :gen-class nil}}
-                    sample-body])))))
+                    sample-body])))
+    (is (= (set (:require-as (regrow [{} sample-body])))
+           '#{[clojure.java.io :as io]
+              [clojure.string :as string]
+              [clojure.set :as set]})
+        "Should prefer candidate '[clojure.string :as string]")))
 
 (deftest ^:unit test-grow-preserve
   (let [in-orig? (in-originals-pred '((java.util Date UUID)))]


### PR DESCRIPTION
Hello,

This branch fixes an issue where slamhound chooses the wrong :require-as libspec when two namespaces contain the same var:

``` clojure
;; alpha/beta.clj
(ns alpha.beta)

(defn hello [])

;; alpha/gamma.clj
(ns alpha.gamma)

(defn hello [])

;; alpha/core.clj
(ns alpha.core
  (:require [alpha.beta :as beta]
            [alpha.gamma :as gamma]))

(beta/hello)
(gamma/hello)
```

Running slamhound on alpha/core.clj produces the erroneous ns form:

``` clojure
(ns alpha.core
  (:require [alpha.beta :as beta]
            [alpha.beta :as gamma]))
```

This is due to `in-originals-pred` erroneously returning a true value for the candidate `[alpha.beta :as gamma]` with the original requires above.

Matching the full candidate against a regular set of fully qualified symbols and libspecs avoids this error, assuming the candidate is a regular, fully qualified libspec itself.

The commit messages go into a little more detail if this is a bit unclear.

This branch also addresses issue #35, at least @kenrestivo's second comment about slamhound not respecting the original requires. I couldn't reproduce his initial example.

Please tell me if you would like me to squash the branch into a single commit or if you would like to see any changes.

Cheers,
Sung Pae
