### PR TITLE
Fix docstring unescaping

### DIFF
--- a/src/slam/hound/prettify.clj
+++ b/src/slam/hound/prettify.clj
@@ -61,7 +61,7 @@
         (when (or doc-str attr-map (seq references))
           ((formatter-out "~@:_")))
         (when doc-str
-          (cl-format true "\"~a\"~:[~;~:@_~]" doc-str
+          (cl-format true "~s~:[~;~:@_~]" doc-str
                      (or attr-map (seq references))))
         (when attr-map
           ((formatter-out "~w~:[~;~:@_~]") attr-map (seq references)))

--- a/test/slam/hound/stitch_test.clj
+++ b/test/slam/hound/stitch_test.clj
@@ -4,7 +4,7 @@
                                        sort-subclauses collapse-clause]]))
 
 (def sample-ns-form '(ns slamhound.sample
-                       "Testing some things going on here."
+                       "Testing some \"things\" going on here."
                        (:require [clojure.java.io :as io]
                                  [clojure.set :as set]
                                  [slam.hound.stitch :refer [ns-from-map]]
@@ -17,7 +17,7 @@
 
 (def sample-ns-map
   {:name 'slamhound.sample
-   :meta {:doc "Testing some things going on here."}
+   :meta {:doc "Testing some \"things\" going on here."}
    :require-refer '[[slam.hound.stitch :refer [ns-from-map]]
                     [clojure.test :refer [is]]
                     [clojure.test :refer [deftest]]]
@@ -33,7 +33,7 @@
 ;; It *should* be covered by tests for stitch-up
 (deftest ^:unit test-sort
   (is (= {:name 'slamhound.sample
-          :meta {:doc "Testing some things going on here."}
+          :meta {:doc "Testing some \"things\" going on here."}
           :require-refer '[[clojure.test :refer [deftest]]
                            [clojure.test :refer [is]]
                            [slam.hound.stitch :refer [ns-from-map]]]
@@ -63,7 +63,7 @@
 
 (deftest ^:unit test-stitch-up
   (is (= "(ns slamhound.sample
-  \"Testing some things going on here.\"
+  \"Testing some \\\"things\\\" going on here.\"
   (:require [clojure.java.io :as io]
             [clojure.set :as set]
             [clojure.test :refer [deftest is]]


### PR DESCRIPTION
Addresses #40

prettify used the cl-format ~A directive to print strings, then
re-surrounded them with quotes. This erroneously unescaped the string.

The proper way is to use the ~S directive to print the string as an
S-expression, escaping both quotes and backslashes to survive a (read)
correctly.

refer: https://www.cs.cmu.edu/afs/cs.cmu.edu/project/ai-repository/ai/html/cltl/clm/node200.html#SECTION002633000000000000000
