### PR TITLE
Don't print a space after a single :exclude

### DIFF
--- a/src/slam/hound/prettify.clj
+++ b/src/slam/hound/prettify.clj
@@ -35,7 +35,7 @@
                                             "~<(~;~@{~w~^ ~:_~}~;)~:>"))
                            lis)
                           (write-out lis)))
-                      (apply (formatter-out "~w ~:i~@{~w~^ ~:_~}") arg)))
+                      (apply (formatter-out "~w~^ ~:i~@{~w~^ ~:_~}") arg)))
                   (when (next args)
                     ((formatter-out "~_"))))
                 (do


### PR DESCRIPTION
Fixes case where

```
    (:refer-clojure :exclude [sym])
```

prints as

```
    (:refer-clojure :exclude [sym ])
```

EDIT: Improved patch, amended, and force pushed
