### PR TITLE
Preserve file comment headers

### DIFF
--- a/src/slam/hound.clj
+++ b/src/slam/hound.clj
@@ -1,9 +1,10 @@
 (ns slam.hound
   (:require [clojure.java.io :as io]
+            [clojure.string :as string]
             [slam.hound.asplode :refer [asplode]]
             [slam.hound.regrow :refer [regrow]]
             [slam.hound.stitch :refer [stitch-up]])
-  (:import (java.io File FileReader PushbackReader)))
+  (:import (java.io File PushbackReader)))
 
 (defn reconstruct [filename]
   ;; Reconstructing consists of three distinct phases:
@@ -13,21 +14,51 @@
       regrow
       stitch-up))
 
+(defn read-comment-header
+  "Read leading blank and comment lines from rdr."
+  [^PushbackReader rdr]
+  ;; An implementation using bufferedReader#readLine would be simpler, but
+  ;; would have to make an assumption about what kind of line terminators the
+  ;; file actually contains.
+  (loop [buf (StringBuilder.) state :ws]
+    (let [c (.read rdr)]
+      (if (= c -1) ; EOF
+        (str buf)
+        (let [ch (char c)]
+          (case state
+            :comment (recur (.append buf ch)
+                            ;; CRLF and LF both end with LF
+                            (if (= ch \newline) :ws :comment))
+            :ws (cond (= ch \;) (recur (.append buf ch) :comment)
+                      (Character/isWhitespace ch) (recur (.append buf ch) :ws)
+                      :else (do (.unread rdr c) (str buf)))))))))
+
+(defn- tidy-comment-header [s]
+  (-> s
+      (string/replace-first #"(?s)\A\s*\n" "")
+      (string/trimr)
+      (str "\n\n")))
+
 (defn swap-in-reconstructed-ns-form
   "Reconstruct file's ns form and rewrite the file on disk with the new form."
   [file]
   (let [tmp-file (doto (File/createTempFile "slamhound_tmp" ".clj")
                    .deleteOnExit)
-        _ (io/copy file tmp-file)
+        _ (do (io/copy file tmp-file)
+              (io/copy "" file))
         new-ns (.trim (reconstruct tmp-file))]
-    (with-open [rdr (PushbackReader. (io/reader tmp-file))]
+    (with-open [rdr (PushbackReader. (io/reader tmp-file))
+                writer (io/writer file :append true)]
+      ;; Preserve comment header
+      (let [header (read-comment-header rdr)]
+        (when-not (string/blank? header)
+          (io/copy (tidy-comment-header header) writer)))
       ;; move the reader past the namespace form; discard value
       (read rdr)
-      ;; copy in the reconstructed ns form
-      (io/copy new-ns file)
+      ;; append the reconstructed ns form
+      (io/copy new-ns writer)
       ;; append the body
-      (with-open [writer (io/writer file :append true)]
-        (io/copy rdr writer)))))
+      (io/copy rdr writer))))
 
 (defn -main
   "Takes a file or dir and rewrites the .clj files with reconstructed ns forms."

--- a/test/slam/hound_test.clj
+++ b/test/slam/hound_test.clj
@@ -1,8 +1,23 @@
 (ns slam.hound-test
   (:require [clojure.java.io :as io]
             [clojure.test :refer [deftest is testing]]
-            [slam.hound :refer [reconstruct -main]])
-  (:import (java.io File StringReader)))
+            [slam.hound :refer [read-comment-header reconstruct -main]])
+  (:import (java.io File PushbackReader StringReader)))
+
+(deftest ^:unit test-read-comment-header
+  (testing "preserves comments at top of file"
+    (is (= ";;\n;; Copyright © Phil Hagelberg\n;;\n\n"
+           (read-comment-header
+             (PushbackReader.
+               (StringReader.
+                 ";;\n;; Copyright © Phil Hagelberg\n;;\n\n(ns test)"))))))
+  (testing "returns headers faithfully"
+    (is (= "\n\r\n\t;; COPYRIGHT  \n\r\n\t;; LICENSE  \n\r\n"
+           (read-comment-header
+             (PushbackReader.
+               (StringReader.
+                 (str "\n\r\n\t;; COPYRIGHT  \n\r\n"
+                      "\t;; LICENSE  \n\r\n(ns test)"))))))))
 
 (def basic-ns (str '(ns slamhound.sample
                       "Testing some things going on here."


### PR DESCRIPTION
Comment headers in files often contain important metadata about the file
(copyright, license, contact information) that should not be removed.

A note about the implementation: read-comment-header can be implemented
in ~3 lines by using .readLine. However, .readLine discards newlines, so
slamhound would have to make an assumption about what newlines have been
discarded, which is a mistake.

e.g. Editing Unix source files on a Windows machine would produce \r\n
     line terminators if we join the header lines with
     (System/getProperty "line.separator")

PS. I didn't see an appropriate namespace for the new functions, so I
just placed them in slam.hound.
