### PR TITLE
Fix multiline docstrings

### DIFF
--- a/src/slam/hound/prettify.clj
+++ b/src/slam/hound/prettify.clj
@@ -1,8 +1,9 @@
 (ns slam.hound.prettify
   "Format a namespace declaration using pretty print with custom dispatch."
-  (:require [clojure.pprint :refer [code-dispatch pprint with-pprint-dispatch
-                                    cl-format pprint-logical-block
-                                    pprint-newline formatter-out write-out]]))
+  (:require [clojure.pprint :refer [cl-format code-dispatch formatter-out
+                                    pprint pprint-logical-block pprint-newline
+                                    with-pprint-dispatch write-out]]
+            [clojure.string :refer [escape]]))
 
 (defn- brackets
   "Figure out which kind of brackets to use"
@@ -61,8 +62,9 @@
         (when (or doc-str attr-map (seq references))
           ((formatter-out "~@:_")))
         (when doc-str
-          (cl-format true "~s~:[~;~:@_~]" doc-str
-                     (or attr-map (seq references))))
+          (let [doc-str (escape doc-str {\\ "\\\\" \" "\\\""})]
+            (cl-format true "\"~a\"~:[~;~:@_~]" doc-str
+                       (or attr-map (seq references)))))
         (when attr-map
           ((formatter-out "~w~:[~;~:@_~]") attr-map (seq references)))
         (when references

--- a/test/slam/hound/stitch_test.clj
+++ b/test/slam/hound/stitch_test.clj
@@ -4,7 +4,8 @@
                                        sort-subclauses collapse-clause]]))
 
 (def sample-ns-form '(ns slamhound.sample
-                       "Testing some \"things\" going on here."
+                       "Testing some \"things\"
+going on here."
                        (:require [clojure.java.io :as io]
                                  [clojure.set :as set]
                                  [slam.hound.stitch :refer [ns-from-map]]
@@ -17,7 +18,7 @@
 
 (def sample-ns-map
   {:name 'slamhound.sample
-   :meta {:doc "Testing some \"things\" going on here."}
+   :meta {:doc "Testing some \"things\"\ngoing on here."}
    :require-refer '[[slam.hound.stitch :refer [ns-from-map]]
                     [clojure.test :refer [is]]
                     [clojure.test :refer [deftest]]]
@@ -33,7 +34,7 @@
 ;; It *should* be covered by tests for stitch-up
 (deftest ^:unit test-sort
   (is (= {:name 'slamhound.sample
-          :meta {:doc "Testing some \"things\" going on here."}
+          :meta {:doc "Testing some \"things\"\ngoing on here."}
           :require-refer '[[clojure.test :refer [deftest]]
                            [clojure.test :refer [is]]
                            [slam.hound.stitch :refer [ns-from-map]]]
@@ -63,7 +64,7 @@
 
 (deftest ^:unit test-stitch-up
   (is (= "(ns slamhound.sample
-  \"Testing some \\\"things\\\" going on here.\"
+  \"Testing some \\\"things\\\"\ngoing on here.\"
   (:require [clojure.java.io :as io]
             [clojure.set :as set]
             [clojure.test :refer [deftest is]]


### PR DESCRIPTION
(I screwed up multiline docstrings. Sorry! I don't usually write ns docstrings, and the tests didn't cover this case. This patch should correct all of this.)

Commit e66a40683e2ebf94a1e3bea53706c55ab879c7cd fixed unintentional
unescaping of docstrings, but also broke multiline docstrings:

```
    (ns example
      "Foo
       Bar
       Baz")

    =>

    (ns example
      "Foo\n   Bar\n   Baz")
```

This approach manually escapes \ and " inside of docstrings, but leaves
newlines and other characters as is so that the string is reprinted as
intended.
