### PR TITLE
Preserve header comments

### DIFF
--- a/slamhound.el
+++ b/slamhound.el
@@ -61,7 +61,9 @@
     (if (string-match "^:error \\(.*\\)" result)
         (error (match-string 1 result))
       (goto-char (point-min))
-      (kill-sexp)
+      ;; skip any header comments before the ns
+      (forward-sexp)
+      (backward-kill-sexp)
       (insert result))))
 
 (provide 'slamhound)


### PR DESCRIPTION
When deleting the first sexp in the file any header comments were nuked
as well. This change preserves them.
