### PR TITLE
support newly nrepl

### DIFF
--- a/slamhound.el
+++ b/slamhound.el
@@ -57,14 +57,17 @@
   Requires active nrepl or slime connection."
   (interactive)
   (let* ((code (slamhound-clj-string buffer-file-name))
-         (result (plist-get (nrepl-send-string-sync code) :stdout)))
-    (if (string-match "^:error \\(.*\\)" result)
-        (error (match-string 1 result))
+         (result (nrepl-send-string-sync code))
+         (out (if (plist-member result :stdout)
+                  (plist-get result :stdout)
+                (lax-plist-get (cdr result) "out"))))
+    (if (string-match "^:error \\(.*\\)" out)
+        (error (match-string 1 out))
       (goto-char (point-min))
       ;; skip any header comments before the ns
       (forward-sexp)
       (backward-kill-sexp)
-      (insert result))))
+      (insert out))))
 
 (provide 'slamhound)
 ;;; slamhound.el ends here


### PR DESCRIPTION
My nREPL is cider 0.8.1.
CIDER 0.8.1 (package: 20141124.2036) (Java 1.7.0_71, Clojure 1.6.0, nREPL 0.2.6) 
In that case, return value of `nrepl-send-string-sync` function is looks like,

```
(dict "err" "..." "id" "9" "session" "b614a748-c33d-49d8-9b99-4dcc678fdcf5" "out" "(ns clj-tms.http                                                                                                             
  (:require [cheshire.core :as json]                                                                                                                                                                            
            [clj-http.client :as http]))" "ns" "user" "value" "nil" "status" ("done")) 
```

Key `:stdout` change to `out` string.
So I fixed it.
How about?
