### PR TITLE
Adjust to latest nrepl API

### DIFF
--- a/slamhound.el
+++ b/slamhound.el
@@ -57,7 +57,7 @@
   Requires active nrepl or slime connection."
   (interactive)
   (let* ((code (slamhound-clj-string buffer-file-name))
-         (result (plist-get (nrepl-send-string-sync code) :stdout)))
+         (result (nrepl-dict-get (nrepl-send-string-sync code) "out")))
     (if (string-match "^:error \\(.*\\)" result)
         (error (match-string 1 result))
       (goto-char (point-min))


### PR DESCRIPTION
Here's a somewhat duplicative pull request with #84 

Current slamhound.el doesn't work with current nrepl as they changed the function being called to return things in a different format, now encapsulated by their function 'nrepl-dict-get'. 