### PR TITLE
Fix detection of dotted ns alias

### DIFF
--- a/dev-resources/test-dotted-alias.in
+++ b/dev-resources/test-dotted-alias.in
@@ -1,0 +1,7 @@
+(ns slamhound.sample
+  "Testing using dot in alias"
+  (:require
+    [clojure.string :as string]
+    [clojure.java.io :as java.io]))
+
+(java.io/resource "some-resource")

--- a/dev-resources/test-dotted-alias.out
+++ b/dev-resources/test-dotted-alias.out
@@ -1,0 +1,5 @@
+(ns slamhound.sample
+  "Testing using dot in alias"
+  (:require [clojure.java.io :as java.io]))
+
+(java.io/resource "some-resource")

--- a/src/slam/hound/regrow.clj
+++ b/src/slam/hound/regrow.clj
@@ -78,6 +78,7 @@
                        "Can't resolve: "
                        "No such namespace: "
                        "Cannot resolve type: " ; core.typed
+                       "java.lang.ClassNotFoundException:? " ; http://dev.clojure.org/jira/browse/CLJ-1403
                        ]
                       (mapv #(Pattern/compile (str % sym-pat))))]
     (into [#"No such var: (\S+)/.*"] patterns)))
@@ -99,6 +100,9 @@
                    (re-find #"No such (var|namespace)" msg)
                    [:alias]
 
+                   (re-find #"java\.lang\.ClassNotFoundException" msg)
+                   [:alias]
+
                    :else
                    [:refer :import])
           rename? (some #{sym} (mapcat (comp vals val) (:rename old-ns-map)))]
@@ -115,7 +119,7 @@
       (try
         (eval `(do ~ns-form ~@body nil))
         (catch Exception e
-          (or (failure-details (.getMessage e) (:old ns-map))
+          (or (failure-details (str (type e) " " (.getMessage e)) (:old ns-map))
               (do (debug :not-found ns-form)
                   (throw e))))
         (finally

--- a/test/slam/hound_test.clj
+++ b/test/slam/hound_test.clj
@@ -85,3 +85,10 @@
     [tmp]
     (let [buf (reconstruct tmp)]
       (spit tmp buf))))
+
+(deftest ^:integration test-using-dots-in-alias
+  (with-transform-test "dots in ns alias are fine"
+    {:in "test-dotted-alias.in"
+     :out "test-dotted-alias.out"}
+    [tmp]
+    (swap-in-reconstructed-ns-form tmp)))


### PR DESCRIPTION
Due to http://dev.clojure.org/jira/browse/CLJ-1403, a dotted ns alias like `[clojure.java.io :as java.io]` or `[clj-time.coerce :as time.coerce]` throws a `ClassNotFoundException` with the ns alias as the message. Identifying this special case in the regrow process allows us to keep looking for the correct alias
