### PR TITLE
Fix regrow function for aliases containing non-word characters

### DIFF
--- a/src/slam/hound/regrow.clj
+++ b/src/slam/hound/regrow.clj
@@ -93,7 +93,7 @@
                      [:refer :import]
                      [:import :refer])
 
-                   (re-find #"Unable to resolve var: \w+/" msg)
+                   (re-find #"Unable to resolve var: \S+/" msg)
                    [:alias :refer]
 
                    (re-find #"No such (var|namespace)" msg)


### PR DESCRIPTION
Slamhound was failing for some code like:

```clojure
(with-redefs [alias-with-dash/foo (constantly "bar")] ...)
```

I finally tracked it down to the regex that matches the "Unable to resolve var:" error. This regex was only matching aliases that contained alphanumeric characters. This PR changes the regex to match all non-whitespace characters.