### PR TITLE
Remove clojurescript :dev dependency that fails to resolve.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,11 +6,7 @@
   :main ^:skip-aot slam.hound
   :dependencies [[org.clojure/clojure "1.4.0"]]
   :profiles {:dev {:dependencies [[org.clojure/tools.trace "0.7.3"]
-                                  ;; Last version of CLJS compatible with
-                                  ;; Clojure 1.4.0
-                                  [org.clojure/clojurescript "0.0-1535"]
                                   [org.clojars.runa/clj-schema "0.7.0"]
                                   [korma "0.3.0-beta11"]]}}
-  :test-selectors {:default (constantly true)
-                   :integration :integration
+  :test-selectors {:integration :integration
                    :unit :unit})


### PR DESCRIPTION
The Clojurescript dependency in the `:dev` profile fails to resolve, and is not needed for the tests to pass. I don't know why it was added, so I won't remove it directly myself.

```
Retrieving org/apache/ant/ant-launcher/1.8.2/ant-launcher-1.8.2.jar from central
Retrieving com/googlecode/jarjar/jarjar/1.1/jarjar-1.1.jar from central
Retrieving org/apache/ant/ant/1.8.2/ant-1.8.2.jar from central
Retrieving com/google/guava/guava/13.0.1/guava-13.0.1.jar from central
Retrieving com/google/javascript/closure-compiler/r2180/closure-compiler-r2180.jar from central
Could not transfer artifact com.google.javascript:closure-compiler:jar:r2180 from/to central (https://repo1.maven.org/maven2/): GET request of: com/google/javascript/closure-compiler/r2180/closure-compiler-r2180.jar from central failed
Could not find artifact com.google.javascript:closure-compiler:jar:r2180 in clojars (https://clojars.org/repo/)
Could not transfer artifact com.google.guava:guava:jar:13.0.1 from/to central (https://repo1.maven.org/maven2/): GET request of: com/google/guava/guava/13.0.1/guava-13.0.1.jar from central failed
Could not find artifact com.google.guava:guava:jar:13.0.1 in clojars (https://clojars.org/repo/)
Could not find artifact com.google.guava:guava:jar:13.0.1 in caja (http://google-caja.googlecode.com/svn/maven)
Could not transfer artifact org.apache.ant:ant:jar:1.8.2 from/to central (https://repo1.maven.org/maven2/): GET request of: org/apache/ant/ant/1.8.2/ant-1.8.2.jar from central failed
Could not find artifact org.apache.ant:ant:jar:1.8.2 in clojars (https://clojars.org/repo/)
Could not find artifact org.apache.ant:ant:jar:1.8.2 in caja (http://google-caja.googlecode.com/svn/maven)
Could not transfer artifact org.apache.ant:ant-launcher:jar:1.8.2 from/to central (https://repo1.maven.org/maven2/): GET request of: org/apache/ant/ant-launcher/1.8.2/ant-launcher-1.8.2.jar from central failed
Could not find artifact org.apache.ant:ant-launcher:jar:1.8.2 in clojars (https://clojars.org/repo/)
Could not find artifact org.apache.ant:ant-launcher:jar:1.8.2 in caja (http://google-caja.googlecode.com/svn/maven)
Could not transfer artifact com.googlecode.jarjar:jarjar:jar:1.1 from/to central (https://repo1.maven.org/maven2/): GET request of: com/googlecode/jarjar/jarjar/1.1/jarjar-1.1.jar from central failed
Could not find artifact com.googlecode.jarjar:jarjar:jar:1.1 in clojars (https://clojars.org/repo/)
Could not find artifact com.googlecode.jarjar:jarjar:jar:1.1 in caja (http://google-caja.googlecode.com/svn/maven)
This could be due to a typo in :dependencies or network issues.
If you are behind a proxy, try setting the 'http_proxy' environment variable.
```